### PR TITLE
Added comparision with existing FullLookAndFeel xaml file

### DIFF
--- a/ResMerger/ResourceMerger.cs
+++ b/ResMerger/ResourceMerger.cs
@@ -138,13 +138,32 @@ namespace ResMerger
                     outputDoc.Root.SetAttributeValue(attribute.Name, attribute.Value);
 
                 // add elements
-                outputDoc.Root.Add(item.Value.Document.Root.Elements().Where(e => !e.Name.LocalName.StartsWith(resDictString))); 
+                outputDoc.Root.Add(item.Value.Document.Root.Elements().Where(e => !e.Name.LocalName.StartsWith(resDictString)));
+            }
+
+            using (var ms = new MemoryStream())
+            {
+                outputDoc.Save(ms);
+
+                if (OutputEqualsExistingFileContent(Path.Combine(projectPath, relativeOutputFilePath), ms.ToArray()))
+                    return;
             }
 
             // save file
             outputDoc.Save(projectPath + relativeOutputFilePath);
         }
 
+        private static bool OutputEqualsExistingFileContent(string targetFileName, IEnumerable<byte> newFileContent)
+        {
+            var normalizedFileName = targetFileName.Replace("/", "\\");
+
+            // don't check for equality if the FullLookAndFeel.xaml doesn't exist already
+            if (!File.Exists(normalizedFileName))
+                return false;
+
+            var existingFileContentBytes = File.ReadAllBytes(normalizedFileName);
+            return newFileContent.SequenceEqual(existingFileContentBytes); ;
+        }
 
         /// <summary>
         /// Get a collection of resource dictionary source paths respecting the dependencies 


### PR DESCRIPTION
Each time the FullLookAndFeel.xaml is generated, VisualStudio detects a change in the project where this file is used. This change triggers a rebuild for at least one project, even if no changes were made in source code.

This change adds a comparison of the newly generated content with the already existing .xaml file. The FullLookAndFeel will no longer be generated if the newly created content equals the already existing content.
