### PR TITLE
Including external resource dictionaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/.vs/
+bin/
+obj/
+*.csproj.user


### PR DESCRIPTION
The ResMerger fails to include/merge external resource dictionary. Obviously it is not wanted to merge the single resources into the final resource dictionary. With this PR the ResMerger will collect all dictionaries that cannot be resolved and add them as a merged dictionary at the top of the generated dictionary.

The result will look something like:

```xml
<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
  <ResourceDictionary.MergedDictionaries>
    <ResourceDictionary Source="/Some.Library;component/Resources/ExportedResources.xaml" />
  </ResourceDictionary.MergedDictionaries>
   <!-- Here the flat resource list starts -->
  <Thickness x:Key="ControlMargin">4</Thickness>
   ...
```